### PR TITLE
Update for cassandra 1.2.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ local.properties
 
 # TeXlipse plugin
 .texlipse
+
+
+### IntelliJ ###
+.idea
+*.iml

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn clean compile assembly:single && echo "Success! Executable jar is on target directory."
+mvn clean compile -U assembly:single && echo "Success! Executable jar is on target directory."

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn clean compile -U assembly:single && echo "Success! Executable jar is on target directory."
+mvn clean package -U && echo "Success! Executable jar is on target directory."

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
             </goals>
             <configuration>
               <minimizeJar>true</minimizeJar>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>
                 <filter>
                    <artifact>log4j:log4j</artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>1.2.13</version>
+            <version>1.2.15</version>
         </dependency>    
     </dependencies>
     
@@ -17,7 +17,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.4.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -25,50 +25,36 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <minimizeJar>true</minimizeJar>
               <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>com.chaordicsystems.sstableconverter.SSTableConverter</mainClass>
+                </transformer>
+              </transformers>
               <filters>
                 <filter>
-                   <artifact>log4j:log4j</artifact>
-                   <includes>
-                       <include>**</include>
-                   </includes>
-                </filter>
-                <filter>
-                   <artifact>commons-logging:commons-logging</artifact>
-                   <includes>
-                       <include>**</include>
-                   </includes>
+                    <artifact>org.apache.cassandra:cassandra-all</artifact>
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <excludes>
+                        <exlude>
+                            org/apache/cassandra/io/sstable/SSTableReader.class
+                        </exlude>
+                    </excludes>
                 </filter>
               </filters>
-              <artifactSet>
-                <excludes>
-                  <exclude>cassandra-all:org/apache/cassandra/io/sstable/SSTableReader</exclude>
-                </excludes>
-              </artifactSet>
             </configuration>
           </execution>
         </executions>
       </plugin>
-    <plugin>
-      <artifactId>maven-assembly-plugin</artifactId>
-      <configuration>
-        <archive>
-          <manifest>
-            <mainClass>com.chaordicsystems.sstableconverter.SSTableConverter</mainClass>
-          </manifest>
-        </archive>
-        <descriptorRefs>
-          <descriptorRef>jar-with-dependencies</descriptorRef>
-        </descriptorRefs>
-        <appendAssemblyId>false</appendAssemblyId>
-      </configuration>
-    </plugin>
   </plugins>
 </build>  
 
 <properties>
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
 </properties>
 </project>


### PR DESCRIPTION
- Update for cassandra 1.2.15
- Use maven shade for more predictable packaging
- Target java 1.7
